### PR TITLE
Remove Secrets Manager rotation job

### DIFF
--- a/.github/secret-rotation.yml
+++ b/.github/secret-rotation.yml
@@ -4,8 +4,6 @@
 # This config tracks manually-managed secrets so the workflow can surface a GitHub
 # issue ahead of expiry. Update `expires` here whenever you rotate the underlying
 # token in GitHub's settings UI.
-#
-# AWS Secrets Manager entries are auto-rotated on schedule (no expiry tracking needed).
 
 manual_secrets:
   - name: "Claude Code (GitHub classic PAT)"
@@ -30,7 +28,3 @@ manual_secrets:
       - "Update CLAUDE_CODE_OAUTH_TOKEN in this repo's GitHub Secrets"
       - "Update the `expires` field in this file"
 
-aws_secrets_manager:
-  - secret_name: vpn-starter-proxy-api-key
-    description: "VPN Starter Proxy Lambda API key (auto-rotated by Secrets Manager every 30 days)"
-    # Rotation is driven by the schedule on the secret itself; this entry is informational.

--- a/.github/workflows/rotate-secrets.yml
+++ b/.github/workflows/rotate-secrets.yml
@@ -1,7 +1,6 @@
 name: Secret Rotation Monitor
 
-# GitHub does not expose an API to rotate user-level PATs, so this workflow only
-# warns about upcoming expiries. AWS Secrets Manager entries are nudged on schedule.
+# Warns about upcoming expiries for manually-managed secrets (PATs, OAuth tokens, etc.).
 
 on:
   schedule:
@@ -100,40 +99,3 @@ jobs:
               print("Created new issue")
           PYEOF
 
-  rotate-aws-secrets:
-    name: Trigger AWS Secrets Manager rotation
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
-          aws-region: eu-west-1
-
-      - name: Trigger rotation for any AWS secrets in the registry
-        run: |
-          set -euo pipefail
-          python3 -m pip install --quiet pyyaml
-          python3 - <<'PYEOF'
-          import subprocess
-          import yaml
-
-          with open(".github/secret-rotation.yml") as f:
-              config = yaml.safe_load(f)
-
-          for entry in config.get("aws_secrets_manager", []):
-              name = entry["secret_name"]
-              # `rotate-secret` with no args triggers the configured schedule's Lambda;
-              # idempotent — Secrets Manager debounces if a rotation is already in flight.
-              print(f"Triggering rotation for {name}")
-              subprocess.run(
-                  ["aws", "secretsmanager", "rotate-secret",
-                   "--secret-id", name, "--region", "eu-west-1"],
-                  check=True
-              )
-          PYEOF


### PR DESCRIPTION
## Summary

- Removes the `rotate-aws-secrets` workflow job — `vpn-starter-proxy-api-key` has been migrated to SSM Parameter Store, so the `rotate-secret` API calls were failing weekly with `ResourceNotFoundException`
- Removes the `aws_secrets_manager` section from `secret-rotation.yml`
- Cleans up the stale comment in the workflow header