### PR TITLE
fix(security): patch bundled brace-expansion in aws-cdk-lib (GHSA-jxxr-4gwj-5jf2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "tsc",
     "watch": "tsc -w",
     "test": "jest",
-    "cdk": "cdk"
+    "cdk": "cdk",
+    "postinstall": "node scripts/patch-brace-expansion.cjs"
   },
   "devDependencies": {
     "@types/jest": "^30.0.0",

--- a/scripts/patch-brace-expansion.cjs
+++ b/scripts/patch-brace-expansion.cjs
@@ -1,0 +1,44 @@
+/**
+ * Patches brace-expansion bundled inside aws-cdk-lib to fix GHSA-jxxr-4gwj-5jf2.
+ *
+ * brace-expansion@5.0.5 is in the bundledDependencies of aws-cdk-lib (via minimatch)
+ * and cannot be updated via npm overrides. This postinstall script applies the
+ * one-line fix from 5.0.6: adding `&& N.length < max` to the numeric range loop
+ * condition to honour the documented `max` DoS guard.
+ *
+ * Can be removed once aws-cdk-lib ships with brace-expansion >= 5.0.6.
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const VULNERABLE = 'for (let i = x; test(i, y); i += incr) {';
+const PATCHED    = 'for (let i = x; test(i, y) && N.length < max; i += incr) {';
+
+const TARGET_FILES = [
+  'node_modules/aws-cdk-lib/node_modules/brace-expansion/dist/commonjs/index.js',
+  'node_modules/aws-cdk-lib/node_modules/brace-expansion/dist/esm/index.js',
+];
+
+const root = path.resolve(__dirname, '..');
+let patchApplied = false;
+
+for (const relPath of TARGET_FILES) {
+  const filePath = path.join(root, relPath);
+  if (!fs.existsSync(filePath)) continue;
+
+  const src = fs.readFileSync(filePath, 'utf8');
+  if (!src.includes(VULNERABLE)) {
+    console.log(`[patch-brace-expansion] already patched: ${relPath}`);
+    continue;
+  }
+
+  fs.writeFileSync(filePath, src.replaceAll(VULNERABLE, PATCHED), 'utf8');
+  console.log(`[patch-brace-expansion] applied GHSA-jxxr-4gwj-5jf2 fix: ${relPath}`);
+  patchApplied = true;
+}
+
+if (!patchApplied) {
+  console.log('[patch-brace-expansion] nothing to patch');
+}


### PR DESCRIPTION
## Summary

Addresses Dependabot alert #80 — `brace-expansion@5.0.5` bundled inside `aws-cdk-lib@2.257.0`.

### Problem

`brace-expansion@5.0.5` is missing the `&& N.length < max` guard in its numeric-range expansion loop, allowing a crafted large range (e.g. `{1..1000000}`) to bypass the documented `max` DoS limit (CVSS 6.5, moderate — [GHSA-jxxr-4gwj-5jf2](https://github.com/advisories/GHSA-jxxr-4gwj-5jf2)).

The top-level `node_modules/brace-expansion` is already at `5.0.6` (patched) via the existing override in `package.json`. The problem is that `aws-cdk-lib` lists `minimatch` in its `bundledDependencies`, and `minimatch` in turn carries `brace-expansion@5.0.5` packed inside the `aws-cdk-lib` tarball. npm cannot update bundled dependencies via overrides — `npm audit fix --dry-run` explicitly reports:

> `brace-expansion@5.0.5` is a bundled dependency of `aws-cdk-lib@2.257.0`. It cannot be fixed automatically. Check for updates to the aws-cdk-lib package.

There is currently no `aws-cdk-lib` release with `brace-expansion >= 5.0.6` bundled (latest is `2.257.0`).

### Fix

Add `scripts/patch-brace-expansion.cjs`, a `postinstall` hook that applies the one-line upstream fix to both the CommonJS and ESM builds of the bundled package:

```diff
-for (let i = x; test(i, y); i += incr) {
+for (let i = x; test(i, y) && N.length < max; i += incr) {
```

The script is **idempotent** — it checks whether the vulnerable string is still present before writing, so once `aws-cdk-lib` ships a version with `brace-expansion >= 5.0.6` bundled the script will silently no-op and can then be removed along with the `postinstall` entry.

## Test plan

- [x] `node scripts/patch-brace-expansion.cjs` applies fix and reports patched files
- [x] Running the script a second time reports "already patched / nothing to patch" (idempotent)
- [x] `grep` confirms both `dist/commonjs/index.js` and `dist/esm/index.js` now contain `&& N.length < max`
- [x] `npm test` passes the same tests as before (1 pre-existing unrelated failure — CDK feature-flag issue in `vpn-deploy.test.ts`)
- [ ] Remove `postinstall` + script once `aws-cdk-lib` bundles `brace-expansion >= 5.0.6`

---
_Generated by [Claude Code](https://claude.ai/code/session_01BNiKR2ufC6pEMVrptF3fxu)_