### PR TITLE
fix(deps): upgrade aws-cdk-lib to 2.258.0 to resolve brace-expansion DoS (GHSA-jxxr-4gwj-5jf2)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "vpn-deploy",
       "version": "0.1.0",
       "dependencies": {
-        "aws-cdk-lib": "^2.257.0",
+        "aws-cdk-lib": "^2.258.0",
         "constructs": "^10.6.0",
         "fast-xml-parser": "^5.8.0",
         "source-map-support": "^0.5.21"
@@ -41,21 +41,21 @@
       }
     },
     "node_modules/@aws-cdk/asset-awscli-v1": {
-      "version": "2.2.273",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.273.tgz",
-      "integrity": "sha512-X57HYUtHt9BQrlrzUNcMyRsDUCoakYNnY6qh5lNwRCHPtQoTfXmuISkfLk0AjLkcbS5lw1LLTQFiQhTDXfiTvg==",
+      "version": "2.2.282",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.282.tgz",
+      "integrity": "sha512-7hKMi5tTxDcKGIMIOq14PnY0GBcugW33Uh/2YHDZiEwSxLeFOCYBwhR+BFXONb/EJeVI3RETFgailNZbkcKF6g==",
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/asset-node-proxy-agent-v6": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.1.tgz",
-      "integrity": "sha512-We4bmHaowOPHr+IQR4/FyTGjRfjgBj4ICMjtqmJeBDWad3Q/6St12NT07leNtyuukv2qMhtSZJQorD8KpKTwRA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.2.tgz",
+      "integrity": "sha512-pDiuqH+qY3zM9lhhLjbKJ1tnKOHzQ2V4Wr/3qsxyKeKAkuPMI/BVGvZG1PbrikUw949cGVTfVEt4ETKKYnrj0Q==",
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "53.26.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-53.26.0.tgz",
-      "integrity": "sha512-UTcu94dxaZOsgF21v0+/giVZeQ0KbFV0dyalJ1pe5AeV23pIB22aB3Z0WNWUZHdhvjaRpxjJ7poXVA8c4BKsaQ==",
+      "version": "54.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-54.2.0.tgz",
+      "integrity": "sha512-u3lFXmiXSBozxGBmKTCVD/2mTDsaXzLZH3KYiIQKcB+zPldXOeE5TnooBgKV9ih2jVTo8ML0HpkhfAq2eiv0eQ==",
       "bundleDependencies": [
         "jsonschema",
         "semver"
@@ -63,7 +63,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "jsonschema": "^1.5.0",
-        "semver": "^7.8.0"
+        "semver": "^7.8.1"
       },
       "engines": {
         "node": ">= 18.0.0"
@@ -78,7 +78,7 @@
       }
     },
     "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
-      "version": "7.8.0",
+      "version": "7.8.1",
       "inBundle": true,
       "license": "ISC",
       "bin": {
@@ -1684,9 +1684,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.257.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.257.0.tgz",
-      "integrity": "sha512-GoHfWklrBJcMwLtDlY64pvaT7cD2KyDXC8sik89DR6jHl6nQsBtYTKSJCM+C/k4jgXaecbv8myNX75FySejq0A==",
+      "version": "2.258.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.258.0.tgz",
+      "integrity": "sha512-OfFfg30ikBRJ3dimlzsWhPIrj6qug1p2XYsdB38CtMtcur7SufzoUczgI6kWjbQkOVcQgYzhzN29DErV0yZG7A==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "@aws-cdk/cloud-assembly-api",
@@ -1703,19 +1703,19 @@
       ],
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-cdk/asset-awscli-v1": "2.2.273",
-        "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.1",
-        "@aws-cdk/cloud-assembly-api": "^2.2.4",
-        "@aws-cdk/cloud-assembly-schema": "^53.25.0",
+        "@aws-cdk/asset-awscli-v1": "2.2.282",
+        "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.2",
+        "@aws-cdk/cloud-assembly-api": "^2.2.5",
+        "@aws-cdk/cloud-assembly-schema": "^54.0.0",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
-        "fs-extra": "^11.3.3",
+        "fs-extra": "^11.3.5",
         "ignore": "^5.3.2",
         "jsonschema": "^1.5.0",
         "mime-types": "^2.1.35",
-        "minimatch": "^10.2.3",
+        "minimatch": "^10.2.5",
         "punycode": "^2.3.1",
-        "semver": "^7.7.4",
+        "semver": "^7.8.1",
         "table": "^6.9.0",
         "yaml": "1.10.3"
       },
@@ -1727,7 +1727,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api": {
-      "version": "2.2.4",
+      "version": "2.2.5",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1738,18 +1738,7 @@
         "node": ">= 18.0.0"
       },
       "peerDependencies": {
-        "@aws-cdk/cloud-assembly-schema": ">=53.25.0"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api/node_modules/semver": {
-      "version": "7.8.0",
-      "inBundle": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
+        "@aws-cdk/cloud-assembly-schema": ">=53.28.0"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {
@@ -1758,7 +1747,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/aws-cdk-lib/node_modules/ajv": {
-      "version": "8.18.0",
+      "version": "8.20.0",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -1811,7 +1800,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/brace-expansion": {
-      "version": "5.0.5",
+      "version": "5.0.6",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -1871,7 +1860,7 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/aws-cdk-lib/node_modules/fs-extra": {
-      "version": "11.3.3",
+      "version": "11.3.5",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -1910,7 +1899,7 @@
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/jsonfile": {
-      "version": "6.2.0",
+      "version": "6.2.1",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -1983,7 +1972,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/semver": {
-      "version": "7.7.4",
+      "version": "7.8.1",
       "inBundle": true,
       "license": "ISC",
       "bin": {
@@ -4263,7 +4252,6 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "typescript": "~6.0.3"
   },
   "dependencies": {
-    "aws-cdk-lib": "^2.257.0",
+    "aws-cdk-lib": "^2.258.0",
     "constructs": "^10.6.0",
     "fast-xml-parser": "^5.8.0",
     "source-map-support": "^0.5.21"


### PR DESCRIPTION
## Summary

- Upgrades `aws-cdk-lib` from `^2.257.0` to `^2.258.0`
- `aws-cdk-lib@2.257.0` bundles `brace-expansion@5.0.5` which is affected by [GHSA-jxxr-4gwj-5jf2](https://github.com/advisories/GHSA-jxxr-4gwj-5jf2) — a DoS vulnerability where large numeric ranges defeat the documented `max` protection (CVSSv3 **6.5 moderate**)
- `aws-cdk-lib@2.258.0` bundles `brace-expansion@5.0.6` which includes the fix
- `npm audit` reports **0 vulnerabilities** after this change

## Background

The existing `"brace-expansion": "^5.0.6"` override in `package.json` does not resolve this because `brace-expansion` is a _bundled_ dependency of `aws-cdk-lib` (shipped inside the tarball), so npm overrides cannot reach it. The only fix is to upgrade `aws-cdk-lib` itself to a version that ships the patched `brace-expansion`.

## Test plan

- [x] `npm audit` reports 0 vulnerabilities
- [x] `npm install` completes cleanly with no errors
- [ ] Run `npm test` to confirm no regressions
- [ ] Run `npm run build` to verify TypeScript compiles cleanly

## Dependabot alert resolved

- [GHSA-jxxr-4gwj-5jf2](https://github.com/advisories/GHSA-jxxr-4gwj-5jf2): brace-expansion large numeric range DoS
- Alert: https://github.com/eamonmason/vpn-deploy/security/dependabot/80

https://claude.ai/code/session_011fEmfLbXwv6ZWnUixHH6bx

---
_Generated by [Claude Code](https://claude.ai/code/session_011fEmfLbXwv6ZWnUixHH6bx)_