### PR TITLE
build(deps): bump aws-cdk-lib to 2.259.0 and AWS SDK to 1.43.29

### DIFF
--- a/layer_requirements.txt
+++ b/layer_requirements.txt
@@ -1,6 +1,6 @@
 annotated-types==0.7.0 ; python_version >= "3.11" and python_version < "4.0"
-boto3==1.43.27 ; python_version >= "3.11" and python_version < "4.0"
-botocore==1.43.28 ; python_version >= "3.11" and python_version < "4.0"
+boto3==1.43.29 ; python_version >= "3.11" and python_version < "4.0"
+botocore==1.43.29 ; python_version >= "3.11" and python_version < "4.0"
 jmespath==1.1.0 ; python_version >= "3.11" and python_version < "4.0"
 pydantic-core==2.47.0 ; python_version >= "3.11" and python_version < "4.0"
 pydantic==2.13.4 ; python_version >= "3.11" and python_version < "4.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1684,9 +1684,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.258.1",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.258.1.tgz",
-      "integrity": "sha512-isYgP0GASgTY99J3753iN6SLP05wEuinToE+p+Yat0d5Xi55iOtd5HFzBBklOb77FO5R3pikY6r9qaRSZUAwWA==",
+      "version": "2.259.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.259.0.tgz",
+      "integrity": "sha512-qcsbyRBZpFMUzx/Nle5vKXFC14Z1VutvAqw6S4Duh3Yj5ZFl4e/RhN2Vg8QmYktxu9l1aF9H5UyF+Xz81qk9gw==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "@aws-cdk/cloud-assembly-api",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "typescript": "~6.0.3"
   },
   "dependencies": {
-    "aws-cdk-lib": "^2.258.1",
+    "aws-cdk-lib": "^2.259.0",
     "constructs": "^10.6.0",
     "fast-xml-parser": "^5.8.0",
     "source-map-support": "^0.5.21"

--- a/poetry.lock
+++ b/poetry.lock
@@ -26,43 +26,43 @@ files = [
 
 [[package]]
 name = "boto3"
-version = "1.42.30"
+version = "1.43.29"
 description = "The AWS SDK for Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "boto3-1.42.30-py3-none-any.whl", hash = "sha256:d7e548bea65e0ae2c465c77de937bc686b591aee6a352d5a19a16bc751e591c1"},
-    {file = "boto3-1.42.30.tar.gz", hash = "sha256:ba9cd2f7819637d15bfbeb63af4c567fcc8a7dcd7b93dd12734ec58601169538"},
+    {file = "boto3-1.43.29-py3-none-any.whl", hash = "sha256:77c27ada27cdbf619a3bbc41fa9e991caef818d3a2988cf92ea722e107d90108"},
+    {file = "boto3-1.43.29.tar.gz", hash = "sha256:354006c512cdb87ef8214a095f2ade961c8145734475cd7a7e6b39260ff5494a"},
 ]
 
 [package.dependencies]
-botocore = ">=1.42.30,<1.43.0"
+botocore = ">=1.43.29,<1.44.0"
 jmespath = ">=0.7.1,<2.0.0"
-s3transfer = ">=0.16.0,<0.17.0"
+s3transfer = ">=0.18.0,<0.19.0"
 
 [package.extras]
 crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "botocore"
-version = "1.42.30"
+version = "1.43.29"
 description = "Low-level, data-driven core of boto 3."
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "botocore-1.42.30-py3-none-any.whl", hash = "sha256:97070a438cac92430bb7b65f8ebd7075224f4a289719da4ee293d22d1e98db02"},
-    {file = "botocore-1.42.30.tar.gz", hash = "sha256:9bf1662b8273d5cc3828a49f71ca85abf4e021011c1f0a71f41a2ea5769a5116"},
+    {file = "botocore-1.43.29-py3-none-any.whl", hash = "sha256:5d62f2a03ed279a50207ca2824e009313df15f082b6bb591a095a4f04c7faef3"},
+    {file = "botocore-1.43.29.tar.gz", hash = "sha256:dce39d33b707aa162aa3820975f99d7f8f746d46576169fb42ce4f2b3b56b261"},
 ]
 
 [package.dependencies]
 jmespath = ">=0.7.1,<2.0.0"
 python-dateutil = ">=2.1,<3.0.0"
-urllib3 = {version = ">=1.25.4,<2.2.0 || >2.2.0,<3", markers = "python_version >= \"3.10\""}
+urllib3 = ">=1.25.4,<2.2.0 || >2.2.0,<3"
 
 [package.extras]
-crt = ["awscrt (==0.29.2)"]
+crt = ["awscrt (==0.32.2)"]
 
 [[package]]
 name = "colorama"
@@ -155,14 +155,14 @@ plugins = ["setuptools"]
 
 [[package]]
 name = "jmespath"
-version = "1.0.1"
+version = "1.1.0"
 description = "JSON Matching Expressions"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "jmespath-1.0.1-py3-none-any.whl", hash = "sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980"},
-    {file = "jmespath-1.0.1.tar.gz", hash = "sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe"},
+    {file = "jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64"},
+    {file = "jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d"},
 ]
 
 [[package]]
@@ -649,14 +649,14 @@ semver = ">=3.0.0,<4.0.0"
 
 [[package]]
 name = "s3transfer"
-version = "0.16.0"
+version = "0.18.0"
 description = "An Amazon S3 Transfer Manager"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "s3transfer-0.16.0-py3-none-any.whl", hash = "sha256:18e25d66fed509e3868dc1572b3f427ff947dd2c56f844a5bf09481ad3f3b2fe"},
-    {file = "s3transfer-0.16.0.tar.gz", hash = "sha256:8e990f13268025792229cd52fa10cb7163744bf56e719e0b9cb925ab79abf920"},
+    {file = "s3transfer-0.18.0-py3-none-any.whl", hash = "sha256:239c13b09e65ad0346e1be7348b8a202dcad44ac7ea7c6eb858fc881dce739b6"},
+    {file = "s3transfer-0.18.0.tar.gz", hash = "sha256:3760b8b7ec1315da54048b2d626276732bee4300d054d492d4e1d43e20d4ecbd"},
 ]
 
 [package.dependencies]


### PR DESCRIPTION
## Summary

Dependency updates to keep all packages current following the security fixes in PRs #43–#60.

### npm
- `aws-cdk-lib` 2.258.1 → **2.259.0** (latest; floor version in `package.json` also bumped to `^2.259.0`)

### pip (poetry.lock + layer_requirements.txt)
| Package | Before | After |
|---|---|---|
| `boto3` | 1.42.30 / 1.43.27 | **1.43.29** |
| `botocore` | 1.42.30 / 1.43.28 | **1.43.29** |
| `s3transfer` | 0.16.0 | **0.18.0** |
| `jmespath` | 1.0.1 | **1.1.0** |

Note: `poetry.lock` and `layer_requirements.txt` were previously out of sync (Dependabot updated each independently). This PR aligns them to the same boto3/botocore release.

## Context

All known Dependabot security alerts for this repo were resolved in PRs #43–#60 (brace-expansion GHSA-jxxr-4gwj-5jf2, urllib3, fast-xml-parser, pydantic-core, actions/checkout). This PR advances the remaining outdated packages to their current published versions.

## Test plan
- [x] `npm audit` reports **0 vulnerabilities**
- [x] `pip-audit --no-deps` reports **0 vulnerabilities** (poetry.lock packages)
- [ ] `npm run build` — TypeScript compiles cleanly
- [ ] `npm test` — Jest suite passes

https://claude.ai/code/session_01BVX7BqChekXL89F9RwXF5k

---
_Generated by [Claude Code](https://claude.ai/code/session_01BVX7BqChekXL89F9RwXF5k)_