### PR TITLE
Refactor WireGuard config management to use dedicated SSM parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,8 +258,37 @@ Provides HTTP API endpoint for starting VPN instances:
    aws ssm put-parameter --name "/vpn-wireguard/WIREGUARD_IMAGE" --value "wireguard-server-2023-11-21-1150" --type SecureString
    aws ssm put-parameter --name "/vpn-wireguard/ZONE_NAME" --value "acme.com" --type String
    aws ssm put-parameter --name "/vpn-wireguard/RECORD_NAME" --value "vpn.acme.com" --type String
-   aws ssm put-parameter --name "/vpn-wireguard/PRIVATE_KEY" --value "<wireguard-client-config>" --type SecureString
    ```
+
+   The WireGuard server config is rendered at instance boot from these
+   parameters in the central region (`eu-west-1`) — the AMI holds no keys:
+
+   ```sh
+   # Server's WireGuard private key
+   aws ssm put-parameter --region eu-west-1 --name "/vpn-wireguard/SERVER_PRIVATE_KEY" \
+     --type SecureString --value "<server-wireguard-private-key>"
+
+   # One line per client device: <device-public-key>,<tunnel-ip/32>
+   # Every device gets its OWN key pair and tunnel IP - never share a key
+   # between devices (the server flaps between endpoints if you do).
+   aws ssm put-parameter --region eu-west-1 --name "/vpn-wireguard/CLIENT_PEERS" \
+     --type String --value "$(printf '%s\n' \
+       '<device1-public-key>,10.0.0.2/32' \
+       '<device2-public-key>,10.0.0.3/32')"
+
+   # Tunnel MTU, used by the server; client configs must use the same value.
+   # Optional - the server defaults to 1420 if unset. See the vpn-client repo
+   # README for how to probe your path MTU and pick this value.
+   aws ssm put-parameter --region eu-west-1 --name "/vpn-wireguard/MTU" \
+     --type String --value "1420"
+   ```
+
+   > **Migrating from the legacy setup:** the old `/vpn-wireguard/PRIVATE_KEY`
+   > parameter (appended verbatim to `wg0.conf` by the previous user-data) is no
+   > longer read. Inspect its contents first
+   > (`aws ssm get-parameter --name /vpn-wireguard/PRIVATE_KEY --with-decryption`),
+   > carry anything still needed over to `SERVER_PRIVATE_KEY`/`CLIENT_PEERS`,
+   > then delete it.
 
    To verify parameters:
 
@@ -270,7 +299,9 @@ Provides HTTP API endpoint for starting VPN instances:
    aws ssm get-parameter --name "/vpn-wireguard/ZONE_NAME"
    aws ssm get-parameter --name "/vpn-wireguard/RECORD_NAME"
    aws ssm get-parameter --name "/vpn-wireguard/WIREGUARD_IMAGE"
-   aws ssm get-parameter --name "/vpn-wireguard/PRIVATE_KEY" --with-decryption
+   aws ssm get-parameter --region eu-west-1 --name "/vpn-wireguard/SERVER_PRIVATE_KEY" --with-decryption
+   aws ssm get-parameter --region eu-west-1 --name "/vpn-wireguard/CLIENT_PEERS"
+   aws ssm get-parameter --region eu-west-1 --name "/vpn-wireguard/MTU"
    ```
 
 5. **Compile the VPN Starter Proxy Lambda:**

--- a/lib/vpn-vm-deploy-stack.ts
+++ b/lib/vpn-vm-deploy-stack.ts
@@ -76,8 +76,13 @@ export class VPNVMDeployStack extends cdk.Stack {
     // Find the Wireguard AMI I created in various regions    
     const wireguard_ami = ec2.MachineImage.fromSsmParameter('/vpn-wireguard/WIREGUARD_IMAGE')
 
-    // Use SSM Parameter Store instead of Secrets Manager for the private key
-    const privateKeyParameterName = '/vpn-wireguard/PRIVATE_KEY';
+    // WireGuard config inputs live in SSM in the central region; the AMI's
+    // render script fetches them at boot (see vpn-image render-wg0.sh)
+    const wireguardParameterNames = [
+      '/vpn-wireguard/SERVER_PRIVATE_KEY',
+      '/vpn-wireguard/CLIENT_PEERS',
+      '/vpn-wireguard/MTU',
+    ];
 
     const vpnInstanceRole = new iam.Role(this, 'VPNInstanceRole', {
       assumedBy: new iam.ServicePrincipal('ec2.amazonaws.com'),
@@ -88,7 +93,8 @@ export class VPNVMDeployStack extends cdk.Stack {
 
     vpnInstanceRole.addToPolicy(new iam.PolicyStatement({
       actions: ['ssm:GetParameter'],
-      resources: [`arn:aws:ssm:${central_region}:${accountId}:parameter${privateKeyParameterName}`],
+      resources: wireguardParameterNames.map(
+        (name) => `arn:aws:ssm:${central_region}:${accountId}:parameter${name}`),
     }));
 
     const vpnInstanceProfile = new iam.CfnInstanceProfile(this, 'VPNInstanceProfile', {
@@ -97,12 +103,9 @@ export class VPNVMDeployStack extends cdk.Stack {
 
     const userData = ec2.UserData.forLinux();
     userData.addCommands(
-      '# UserData version 1.0.3', // Increment version to force changes
-      'sudo yum install -y aws-cli',
-      `PRIVATE_KEY_VALUE=$(aws ssm get-parameter --name ${privateKeyParameterName} --with-decryption --region ${central_region} --query Parameter.Value --output text)`,
-      'sudo wg-quick down wg0 || true', // Add || true to prevent failure if wg0 isn't up
-      'echo "$PRIVATE_KEY_VALUE" | sudo tee -a /etc/wireguard/wg0.conf',
-      'sudo wg-quick up wg0'
+      '# UserData version 2.0.0', // Increment version to force changes
+      `SSM_REGION=${central_region} /opt/wireguard/render-wg0.sh`,
+      'systemctl enable --now wg-quick@wg0'
     );
 
     const vpnASG = new autoscaling.AutoScalingGroup(this, 'VPNASG', {

--- a/src/vpn_toggle/vpn_toggle.py
+++ b/src/vpn_toggle/vpn_toggle.py
@@ -59,8 +59,9 @@ def enable_vpn(asg, region: str, a_record: str, hosted_zone_name: str, client_ip
     new_capacity = update_asg_capacity(asg, region, 1)
     if new_capacity == 1:
         logger.debug("Waiting for the VPN VM to start in region %s", region)
-        # Check ASG if VM is available, up to five times
-        for _ in range(5):
+        # Check ASG if VM is available, for up to a minute (instances routinely
+        # take longer than 25s to reach "running")
+        for _ in range(12):
             up_asg = get_asg(region)
             try:
                 instance = get_instance_from_asg(up_asg, region)

--- a/test/simple-validation.py
+++ b/test/simple-validation.py
@@ -34,10 +34,10 @@ def main():
     # Check TypeScript stack file
     typescript_file = "lib/vpn-vm-deploy-stack.ts"
     ts_required = [
-        "'/vpn-wireguard/PRIVATE_KEY'",
+        "'/vpn-wireguard/SERVER_PRIVATE_KEY'",
+        "'/vpn-wireguard/CLIENT_PEERS'",
         "ssm:GetParameter",
-        "aws ssm get-parameter",
-        "--with-decryption"
+        "render-wg0.sh"
     ]
     ts_forbidden = [
         "secretsmanager:GetSecretValue",
@@ -54,9 +54,9 @@ def main():
     js_file = "lib/vpn-vm-deploy-stack.js"
     if os.path.exists(js_file):
         js_required = [
-            "'/vpn-wireguard/PRIVATE_KEY'",
+            "'/vpn-wireguard/SERVER_PRIVATE_KEY'",
             "'ssm:GetParameter'",
-            "aws ssm get-parameter"
+            "render-wg0.sh"
         ]
         js_forbidden = [
             "secretsmanager",

--- a/test/vpn-deploy.test.ts
+++ b/test/vpn-deploy.test.ts
@@ -27,7 +27,11 @@ test('VPN Stack uses SSM Parameter Store instead of Secrets Manager', () => {
         {
           Action: 'ssm:GetParameter',
           Effect: 'Allow',
-          Resource: 'arn:aws:ssm:eu-west-1:123456789012:parameter/vpn-wireguard/PRIVATE_KEY'
+          Resource: [
+            'arn:aws:ssm:eu-west-1:123456789012:parameter/vpn-wireguard/SERVER_PRIVATE_KEY',
+            'arn:aws:ssm:eu-west-1:123456789012:parameter/vpn-wireguard/CLIENT_PEERS',
+            'arn:aws:ssm:eu-west-1:123456789012:parameter/vpn-wireguard/MTU'
+          ]
         }
       ]
     }


### PR DESCRIPTION
## Summary
This PR refactors the WireGuard server configuration management to use dedicated SSM parameters for server private key, client peers, and MTU settings, replacing the previous monolithic `PRIVATE_KEY` parameter approach. Configuration is now rendered at instance boot from a centralized script rather than appended directly in user data.

## Key Changes

- **SSM Parameter Structure**: Replaced single `/vpn-wireguard/PRIVATE_KEY` parameter with three dedicated parameters:
  - `SERVER_PRIVATE_KEY`: WireGuard server's private key
  - `CLIENT_PEERS`: Client device public keys and tunnel IPs (one per line)
  - `MTU`: Tunnel MTU setting (optional, defaults to 1420)

- **Configuration Rendering**: Updated user data to call `/opt/wireguard/render-wg0.sh` script instead of directly appending key material to `wg0.conf`. The script fetches parameters from SSM at boot time.

- **IAM Permissions**: Updated instance role policy to grant `ssm:GetParameter` access to all three new parameters in the central region.

- **User Data Simplification**: Reduced user data complexity by delegating WireGuard configuration to the AMI's render script. Version bumped to 2.0.0 to force instance refresh.

- **Documentation**: Added comprehensive migration guide for users transitioning from the legacy `PRIVATE_KEY` parameter, including instructions for inspecting and migrating existing configurations.

- **Test Updates**: Updated validation tests and unit tests to verify the new parameter names and render script invocation.

- **Polling Improvement**: Extended ASG readiness check timeout from 5 attempts (~25s) to 12 attempts (~60s) to account for instances taking longer to reach "running" state.

## Implementation Details

The refactoring moves WireGuard configuration responsibility from the CDK stack's user data to the AMI's boot-time render script. This provides better separation of concerns and allows configuration updates without requiring new AMI builds. All three parameters are stored in the central region (`eu-west-1`) and fetched by instances in any region at boot time.

https://claude.ai/code/session_01BeFtTAStiej8VB3vgvSj5k