### PR TITLE
fix(deps): upgrade browserslist to >=4.28.9 to resolve Dependabot HIGH alerts

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     },
     "babel-plugin-istanbul": "^8.0.0",
     "brace-expansion": ">=5.0.9",
+    "browserslist": "^4.28.9",
     "fast-xml-builder": "^1.1.7",
     "fast-uri": "^3.1.2",
     "js-yaml": "^4.3.1"


### PR DESCRIPTION
## Summary

Resolves two **HIGH severity** Dependabot security alerts for `browserslist` (transitive dependency pulled in by `@babel/helper-compilation-targets`).

## Vulnerabilities Fixed

| Advisory | Severity | CVSS | Description |
|---|---|---|---|
| [GHSA-c83g-rgw3-j3cx](https://github.com/advisories/GHSA-c83g-rgw3-j3cx) | HIGH | 7.5 | Unbounded memory growth (no cache eviction) via distinct query results, leading to OOM |
| [GHSA-73wf-gq98-2v4g](https://github.com/advisories/GHSA-73wf-gq98-2v4g) | HIGH | 7.5 | Uncaught crash / prototype write via untrusted `browserslist-stats.json` custom stats (`normalizeStats`) |

Both CVEs affect `browserslist <=4.28.6`. This PR upgrades the transitive dependency from **4.28.2 → 4.28.9**.

## Changes

- **`package.json`**: Added `"browserslist": "^4.28.9"` to the `overrides` section, consistent with the existing pattern for pinning transitive dependencies (e.g. `brace-expansion`, `glob`, `diff`, etc.)
- **`package-lock.json`**: Updated lockfile to reflect the new resolved version

## Verification

```
$ npm audit
found 0 vulnerabilities
```

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013RJv9RUoHvKfF2Ng2USvBo

---
_Generated by [Claude Code](https://claude.ai/code/session_013RJv9RUoHvKfF2Ng2USvBo)_